### PR TITLE
Update App Store button link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,8 +19,8 @@
 		<p class="subtitle">Natural Language Learning App for iPhone</p>
 	</header>
 	<section class="downloads">
-		<div class="buttons">
-			<a href="#"><img src="/images/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg" /></a>
+                <div class="buttons">
+                        <a href="https://apps.apple.com/us/app/uptalk-language-learning/id6483003918"><img src="/images/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg" /></a>
 		</div>
 	</section>
 	<section class="description">


### PR DESCRIPTION
## Summary
- update the App Store download button on the homepage to point to the Uptalk listing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c2e6264883258413d31fc114d312